### PR TITLE
Use authentication code grant instead of password grant.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Change Log
+
+## v2.0.0
+
+v2.0.0 adds support for the OAuth 2 authorization code grant, used by CollectionSpace 8.0.
+
+### Breaking Changes
+
+- The session login method now issues a request for a token using the OAuth 2 authorization code grant, instead of the password grant. This requires a CollectionSpace 8.0 server. A login attempt to an older CollectionSpace server will fail.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cspace-client",
-  "version": "1.1.8",
+  "version": "2.0.0-rc.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cspace-client",
-      "version": "1.1.8",
+      "version": "2.0.0-rc.1",
       "license": "ECL-2.0",
       "dependencies": {
         "cspace-api": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cspace-client",
-  "version": "1.1.8",
+  "version": "2.0.0-rc.1",
   "description": "CollectionSpace client for browsers and Node.js",
   "author": "Ray Lee <ray.lee@lyrasis.org>",
   "license": "ECL-2.0",

--- a/src/tokenHelpers.js
+++ b/src/tokenHelpers.js
@@ -18,3 +18,27 @@ export const isLocalStorageAvailable = () => {
     return false;
   }
 };
+
+const base64Decode = (encoded) => {
+  if (typeof window !== 'undefined') {
+    // We're in a browser.
+
+    return window.atob(encoded)
+      .split('')
+      // eslint-disable-next-line prefer-template
+      .map((c) => '%' + ('00' + c.charCodeAt(0).toString(16)).slice(-2))
+      .join('');
+  }
+
+  // We're in Node.
+
+  return Buffer.from(encoded, 'base64').toString('utf-8');
+};
+
+export const parseJwt = (token) => {
+  const urlSafeBase64 = token.split('.')[1];
+  const base64 = urlSafeBase64.replace(/-/g, '+').replace(/_/g, '/');
+  const json = decodeURIComponent(base64Decode(base64));
+
+  return JSON.parse(json);
+};

--- a/test/integration/crud.test.js
+++ b/test/integration/crud.test.js
@@ -1,5 +1,14 @@
 /* global globalThis */
 
+// These integration tests are disabled as of version 2.0.0, because they require authenticating as
+// a reader and an administrator. Since we now use the OAuth authorization code grant instead of
+// the password grant, user authentication is no longer the responsibility (or know-how) of this
+// package. These tests should be done at a higher level, probably as Selenium tests of the CSpace
+// UI.
+//
+// These tests could potentially be restored if we add support for long-lived API tokens associated
+// with users.
+
 import chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';
 import client from '../../src/client';
@@ -29,7 +38,13 @@ const readerSessionConfig = {
   password: 'reader',
 };
 
-describe(`crud operations on ${clientConfig.url}`, function suite() {
+describe('Disabled tests', () => {
+  it('should do nothing', () => {
+    // This is just here to keep npm test happy, since all the actual tests are disabled (skipped).
+  });
+});
+
+describe.skip(`crud operations on ${clientConfig.url}`, function suite() {
   this.timeout(20000);
 
   const cspace = client(clientConfig);

--- a/test/specs/session.spec.js
+++ b/test/specs/session.spec.js
@@ -14,31 +14,23 @@ describe('session', () => {
 
     it('should set default options', () => {
       session().config().should.deep.equal({
-        username: '',
+        authCode: '',
+        codeVerifier: '',
+        redirectUri: '',
       });
     });
 
     it('should override default options with passed options', () => {
       const config = {
-        username: 'user@collectionspace.org',
-        password: 'secret',
+        authCode: 'abcd',
+        codeVerifier: '123',
+        redirectUri: '/authorized',
       };
 
       session(config).config().should.deep.equal({
-        username: 'user@collectionspace.org',
-      });
-    });
-  });
-
-  describe('#config()', () => {
-    it('should omit the password', () => {
-      const config = {
-        username: 'user@collectionspace.org',
-        password: 'secret',
-      };
-
-      session(config).config().should.deep.equal({
-        username: 'user@collectionspace.org',
+        authCode: 'abcd',
+        codeVerifier: '123',
+        redirectUri: '/authorized',
       });
     });
   });

--- a/test/specs/tokenManagement.spec.js
+++ b/test/specs/tokenManagement.spec.js
@@ -10,8 +10,10 @@ const clientConfig = {
 };
 
 const sessionConfig = {
-  username: 'user@collectionspace.org',
-  password: 'secret',
+  authCode: 'abcd',
+  clientId: 'cpace-ui',
+  codeVerifier: '123',
+  redirectUri: '/authorized',
 };
 
 let accessToken;
@@ -42,7 +44,7 @@ describe(`token management on ${clientConfig.url}`, function suite() {
       .be.rejected
   ));
 
-  it('reuses the stored token in a new session with no user', () => {
+  it('reuses the stored token in a new session with no auth code', () => {
     const newSession = cspace.session();
 
     return newSession.read('something').should.eventually
@@ -50,9 +52,9 @@ describe(`token management on ${clientConfig.url}`, function suite() {
       .and.have.deep.property('data.presentedToken', accessToken);
   });
 
-  it('does not reuse the stored token in a new session with a different user', () => {
+  it('does not reuse the stored token in a new session with an auth code', () => {
     const newSession = cspace.session({
-      username: 'somebody@collectionspace.org',
+      authCode: 'xyz',
     });
 
     return newSession.read('something').should.eventually


### PR DESCRIPTION
**What does this do?**

This changes the way that tokens are retrieved from the services layer when logging in. The OAuth authorization code grant is now used, instead of the password grant. In order to support this, the session configuration now accepts the new properties:
- `authCode`
- `codeVerifier`
- `redirectUri`

The `username` and `password` properties, used to support the password grant, no longer have any effect.

This library is only responsible for obtaining a token, given an authorization code. Obtaining the authorization code should be done outside of this library.

**Why are we doing this? (with JIRA link)**

CSpace 8.0 upgrades Spring Security to 5.3, and uses Spring Authorization Server instead of the Spring OAuth2 plugin. These upgrades drop support for the OAuth password grant (which has been removed from the latest versions of OAuth). The recommended approach for web apps is to use the authorization code grant.

**How should this be tested? Do these changes have associated tests?**

This can be tested together with CSpace 8.0 and cspace-ui 9.0. Log in should continue to work with this combination.

Some unit tests still need to be written. These will be in a separate PR.

**Dependencies for merging? Releasing to production?**

None.

**Has the application documentation been updated for these changes?**

n/a

**Did someone actually run this code to verify it works?**

@ray-lee ran this against a local CSpace 8.0 server.